### PR TITLE
Store port version in OTR files

### DIFF
--- a/OTRExporter/Main.cpp
+++ b/OTRExporter/Main.cpp
@@ -72,7 +72,7 @@ static void ExporterProgramEnd()
 	uint32_t crc = 0xFFFFFFFF;
 	const uint8_t endianness = (uint8_t)Endianness::Big;
 
-	std::vector<int16_t> portVersion = {};
+	std::vector<uint16_t> portVersion = {};
 	std::vector<std::string> versionParts = StringHelper::Split(portVersionString, ".");
 
 	// If a major.minor.patch string was not passed in, fallback to 0 0 0 
@@ -81,9 +81,9 @@ static void ExporterProgramEnd()
 	} else {
 		// Parse version values to number
 		for (const auto& val : versionParts) {
-			int16_t num = 0;
+			uint16_t num = 0;
 			try {
-				num = std::stoi(val, nullptr);
+				num = (uint16_t)std::stoi(val, nullptr);
 			} catch (std::invalid_argument &e) {
 				num = 0;
 			} catch (std::out_of_range &e) {

--- a/extract_assets.py
+++ b/extract_assets.py
@@ -8,7 +8,7 @@ import struct
 import subprocess
 import argparse
 
-def BuildOTR(xmlPath, rom, zapd_exe=None, genHeaders=None, customAssetsPath=None, customOtrFile=None):
+def BuildOTR(xmlPath, rom, zapd_exe=None, genHeaders=None, customAssetsPath=None, customOtrFile=None, portVer=None):
     if not zapd_exe:
         zapd_exe = "x64\\Release\\ZAPD.exe" if sys.platform == "win32" else "../ZAPDTR/ZAPD.out"
 
@@ -24,6 +24,9 @@ def BuildOTR(xmlPath, rom, zapd_exe=None, genHeaders=None, customAssetsPath=None
                 "--customOtrFile", customOtrFile, "--otrfile",
                 "oot-mq.otr" if Z64Rom.isMqRom(rom) else "oot.otr"])
 
+    if portVer:
+        exec_cmd.extend(["--portVer", portVer])
+
     print(exec_cmd)
     exitValue = subprocess.call(exec_cmd)
     if exitValue != 0:
@@ -32,7 +35,7 @@ def BuildOTR(xmlPath, rom, zapd_exe=None, genHeaders=None, customAssetsPath=None
         print("Aborting...", file=os.sys.stderr)
         print("\n")
 
-def BuildCustomOtr(zapd_exe=None, assets_path=None, otrfile=None):
+def BuildCustomOtr(zapd_exe=None, assets_path=None, otrfile=None, portVer=None):
     if not zapd_exe:
         zapd_exe = "x64\\Release\\ZAPD.exe" if sys.platform == "win32" else "../ZAPDTR/ZAPD.out"
 
@@ -43,6 +46,9 @@ def BuildCustomOtr(zapd_exe=None, assets_path=None, otrfile=None):
         return
 
     exec_cmd = [zapd_exe, "botr", "-se", "OTR", "--norom", "--customAssetsPath", assets_path, "--customOtrFile", otrfile]
+
+    if portVer:
+        exec_cmd.extend(["--portVer", portVer])
 
     print(exec_cmd)
     exitValue = subprocess.call(exec_cmd)
@@ -63,17 +69,18 @@ def main():
     parser.add_argument("--xml-root", help="Root path for the rom xmls", dest="xml_root", type=str)
     parser.add_argument("--custom-assets-path", help="Path to custom assets for the custom otr file", dest="custom_assets_path", type=str)
     parser.add_argument("--custom-otr-file", help="Name for custom otr file", dest="custom_otr_file", type=str)
+    parser.add_argument("--port-ver", help="Store the port version in the otr", dest="port_ver", type=str)
 
     args = parser.parse_args()
 
     if args.norom:
-        BuildCustomOtr(args.zapd_exe, args.custom_assets_path, args.custom_otr_file)
+        BuildCustomOtr(args.zapd_exe, args.custom_assets_path, args.custom_otr_file, portVer=args.port_ver)
         return
 
     roms = [ Z64Rom(args.rom) ] if args.rom else rom_chooser.chooseROM(args.verbose, args.non_interactive)
     for rom in roms:
         BuildOTR(os.path.join(args.xml_root, rom.version.xml_ver), rom.file_path, zapd_exe=args.zapd_exe, genHeaders=args.gen_headers,
-                 customAssetsPath=args.custom_assets_path, customOtrFile=args.custom_otr_file)
+                 customAssetsPath=args.custom_assets_path, customOtrFile=args.custom_otr_file, portVer=args.port_ver)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
These changes allow a port using OTRExporter to pass in the port version as an argument and have that version saved into a `portVersion` file at the root of the generated OTRs.

Ports can then compare this stored version file at run time to see if an OTR is outdated.

If a port version is not passed in, or an incorrect value is provided (something that is not a semver string), then a default value of `0.0.0` is used.

The major/minor/patch values are stored independently as ints.

These changes can be tested over here: https://github.com/HarbourMasters/Shipwright/pull/3218