### PR TITLE
Place shared scenes in their own location

### DIFF
--- a/OTRExporter/DisplayListExporter.cpp
+++ b/OTRExporter/DisplayListExporter.cpp
@@ -8,6 +8,7 @@
 #include <libultraship/libultra/gbi.h>
 #include <Globals.h>
 #include <iostream>
+#include <regex>
 #include <string>
 #include "MtxExporter.h"
 #include <Utils/DiskFile.h>
@@ -883,17 +884,19 @@ std::string OTRExporter_DisplayList::GetPrefix(ZResource* res)
 	std::string xmlPath = StringHelper::Replace(res->parent->GetXmlFilePath().string(), "\\", "/");
 
 	if (StringHelper::Contains(oName, "_scene") || StringHelper::Contains(oName, "_room")) {
-		prefix = "scenes";
-		if (StringHelper::Contains(xmlPath, "dungeons/")) {
+		prefix = "scenes/shared";
+
+		// Regex for xml paths that are dungeons with unique MQ variants (only the main dungeon, not boss rooms)
+		std::regex dungeonsWithMQ(R"(((ydan)|(ddan)|(bdan)|(Bmori1)|(HIDAN)|(MIZUsin)|(jyasinzou)|(HAKAdan)|(HAKAdanCH)|(ice_doukutu)|(men)|(ganontika))\.xml)");
+
+		if (StringHelper::Contains(xmlPath, "dungeons/") && std::regex_search(xmlPath, dungeonsWithMQ)) {
 			if (Globals::Instance->rom->IsMQ()) {
-				prefix += "/mq";
+				prefix = "scenes/mq";
 			} else {
-				prefix += "/nonmq";
+				prefix = "scenes/nonmq";
 			}
-		} else {
-			prefix += "/shared";
 		}
-    }
+	}
 	else if (StringHelper::Contains(xmlPath, "objects/"))
 		prefix = "objects";
 	else if (StringHelper::Contains(xmlPath, "textures/"))

--- a/OTRExporter/DisplayListExporter.cpp
+++ b/OTRExporter/DisplayListExporter.cpp
@@ -884,11 +884,15 @@ std::string OTRExporter_DisplayList::GetPrefix(ZResource* res)
 
 	if (StringHelper::Contains(oName, "_scene") || StringHelper::Contains(oName, "_room")) {
 		prefix = "scenes";
-        if (Globals::Instance->rom->IsMQ()) {
-            prefix += "/mq";
-        } else {
-            prefix += "/nonmq";
-        }
+		if (StringHelper::Contains(xmlPath, "dungeons/")) {
+			if (Globals::Instance->rom->IsMQ()) {
+				prefix += "/mq";
+			} else {
+				prefix += "/nonmq";
+			}
+		} else {
+			prefix += "/shared";
+		}
     }
 	else if (StringHelper::Contains(xmlPath, "objects/"))
 		prefix = "objects";


### PR DESCRIPTION
This PR makes it so that shared scenes are placed in a new location, and that only explicit main dungeons that have nonmq/mq variants will be in those folders.

This is to help reduce duplicate files that need patching for texture packs.

Can be tested out here: https://github.com/HarbourMasters/Shipwright/pull/3191