### PR TITLE
QA: don’t pass path directly into printf

### DIFF
--- a/OTRExporter/ExporterArchiveOTR.cpp
+++ b/OTRExporter/ExporterArchiveOTR.cpp
@@ -25,7 +25,7 @@ bool ExporterArchiveOtr::Load(bool enableWriting) {
     }
     if (openArchiveSuccess) {
         printf("Opened mpq file ");
-        printf(fullPath.c_str());
+        printf("%s", fullPath.c_str());
         printf("\n");
         mMpq = mpqHandle;
         mPath = fullPath;       


### PR DESCRIPTION
This fixes a potential crash if a file name contains %s or %n [as well as other weird behavior with other formatting arguments]