### PR TITLE
use final when inheriting from ExporterArchive

### DIFF
--- a/OTRExporter/ExporterArchiveO2R.h
+++ b/OTRExporter/ExporterArchiveO2R.h
@@ -10,7 +10,7 @@
 #include <zip.h>
 #include "ExporterArchive.h"
 
-class ExporterArchiveO2R : public ExporterArchive {
+class ExporterArchiveO2R final : public ExporterArchive {
   public:
     ExporterArchiveO2R(const std::string& path, bool enableWriting);
     ~ExporterArchiveO2R();

--- a/OTRExporter/ExporterArchiveOTR.h
+++ b/OTRExporter/ExporterArchiveOTR.h
@@ -10,7 +10,7 @@
 #include <StormLib.h>
 #include "ExporterArchive.h"
 
-class ExporterArchiveOtr : public ExporterArchive {
+class ExporterArchiveOtr final : public ExporterArchive {
   public:
     ExporterArchiveOtr(const std::string& path, bool enableWriting);
     ~ExporterArchiveOtr();


### PR DESCRIPTION
addresses warnings about non-virtual destructors