### PR TITLE
Link OTRExporter against tinyxml2

### DIFF
--- a/OTRExporter/CMakeLists.txt
+++ b/OTRExporter/CMakeLists.txt
@@ -148,6 +148,9 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 	.
 )
 
+find_package(tinyxml2 REQUIRED)
+target_link_libraries(${PROJECT_NAME} PUBLIC tinyxml2::tinyxml2)
+
 find_package(nlohmann_json REQUIRED)
 target_link_libraries(${PROJECT_NAME} PUBLIC nlohmann_json::nlohmann_json)
 


### PR DESCRIPTION
This repository references tinyxml2 extensively but does not list it as a dependency in CMakeLists.txt. This breaks on setups with tinyxml2 installed at a non-standard location, such as /opt.